### PR TITLE
Export additional methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const getPixelCoordinates = require('./src/get-pixel-coordinates');
 const getSiblingTilesAndOffsets = require('./src/get-sibling-tiles-and-offsets');
 const getAllTiles = require('./src/get-all-static-tiles');
 const stitchTiles = require('./src/stitch-tiles');
+const getTileUrl = require('./src/utils/get-tile-url');
 
 
 function makeGetQuilt(coordinates, zoom, length = DEFAULT_LENGTH, decode = true) {
@@ -19,4 +20,10 @@ function makeGetQuilt(coordinates, zoom, length = DEFAULT_LENGTH, decode = true)
   };
 }
 
-module.exports = makeGetQuilt;
+module.exports = { 
+  makeGetQuilt,
+  getPixelCoordinates,
+  getSiblingTilesAndOffsets,
+  stitchTiles,
+  getTileUrl
+ };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const getPixelCoordinates = require('./src/get-pixel-coordinates');
 const getSiblingTilesAndOffsets = require('./src/get-sibling-tiles-and-offsets');
 const getAllTiles = require('./src/get-all-static-tiles');
 const stitchTiles = require('./src/stitch-tiles');
-const getTileUrl = require('./src/utils/get-tile-url');
+const getTileUrl = require('./utils/get-tile-url');
 
 
 function makeGetQuilt(coordinates, zoom, length = DEFAULT_LENGTH, decode = true) {
@@ -20,10 +20,10 @@ function makeGetQuilt(coordinates, zoom, length = DEFAULT_LENGTH, decode = true)
   };
 }
 
-module.exports = { 
+module.exports = {
   makeGetQuilt,
   getPixelCoordinates,
   getSiblingTilesAndOffsets,
   stitchTiles,
   getTileUrl
- };
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const fetch = require('node-fetch');
 jest.mock('node-fetch', () => jest.fn());
 
-const makeGetQuilt = require('../index');
+const { makeGetQuilt } = require('../index');
 const accessToken = process.env.MAPBOX_ACCESS_TOKEN || process.env.MapboxAccessToken;
 
 const fixture = {


### PR DESCRIPTION
This PR includes additional methods in quilt's exports (in addition to `makeGetQuilt`) so that consumers can use the methods as well. 